### PR TITLE
Simplify script and fix escaping

### DIFF
--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -1,8 +1,14 @@
-#!/usr/bin/env sh
-set -eu
+#!/bin/sh
+set -euo pipefail
 
-ENV_JSON=$(env | grep '^REACT_APP_*' | jq -c '. | split("\n") | map(select(. != "")) | map(split("=") | { (.[0]) : .[1] }) | reduce .[] as $item ({}; . * $item)' -R -s)
-ESCAPED_ENV_JSON=$(echo $ENV_JSON | sed 's/\"/\\\"/g' | sed 's/\//\\\//g' | tr -d '\n' | tr -d '[[:blank:]]')
-sed -i 's/%REACT_APP_ENV%/'"$ESCAPED_ENV_JSON"'/g' /var/www/index.html
+# Capture all environment variables starting with REACT_APP_ and make JSON string from them
+ENV_JSON="$(jq --compact-output --null-input 'env | with_entries(select(.key | startswith("REACT_APP_")))')"
+
+# Escape sed replacement's special characters: \, &, /.
+# No need to escape newlines, because --compact-output already removed them.
+# Inside of JSON strings newlines are already escaped.
+ENV_JSON_ESCAPED="$(printf "%s" "${ENV_JSON}" | sed -e 's/[\&/]/\\&/g')"
+
+sed -i "s/%REACT_APP_ENV%/${ENV_JSON_ESCAPED}/g" /var/www/index.html
 
 exec "$@"


### PR DESCRIPTION
- Use jq's built-in env and filtering
- Use jq's compact mode instead of dropping all spaces and endlines
- Escape \ instead of /