### PR TITLE
Remove .env

### DIFF
--- a/.env
+++ b/.env
@@ -1,1 +1,0 @@
-REACT_APP_ENV={}

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -9,6 +9,6 @@ ENV_JSON="$(jq --compact-output --null-input 'env | with_entries(select(.key | s
 # Inside of JSON strings newlines are already escaped.
 ENV_JSON_ESCAPED="$(printf "%s" "${ENV_JSON}" | sed -e 's/[\&/]/\\&/g')"
 
-sed -i "s/%REACT_APP_ENV%/${ENV_JSON_ESCAPED}/g" /var/www/index.html
+sed -i "s/<noscript id=\"env-insertion-point\"><\/noscript>/<script>var ENV=${ENV_JSON_ESCAPED}<\/script>/g" /var/www/index.html
 
 exec "$@"

--- a/public/index.html
+++ b/public/index.html
@@ -23,9 +23,7 @@
       Learn how to configure a non-root public URL by running `npm run build`.
     -->
 
-    <script>
-      var ENV = %REACT_APP_ENV%;
-    </script>
+    <noscript id="env-insertion-point"></noscript>
 
     <title>React App</title>
   </head>


### PR DESCRIPTION
Replace `<script>var env=%REACT_APP_ENV%...` with `<noscript>` placeholder to avoid having to add `REACT_APP_ENV={}` to .env file during development to avoid syntax error.